### PR TITLE
Replace Algolia search with Harper-native HNSW vector search

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,3 +1,4 @@
+# Optional. Enables OpenAI-personalized product descriptions and semantic
+# (vector) product search. Without it, search falls back to a Harper keyword
+# match. Harper itself indexes and searches the vectors with HNSW.
 OPENAI_API_KEY=''
-ALGOLIA_APP_ID=''
-ALGOLIA_API_KEY=''

--- a/README.md
+++ b/README.md
@@ -14,10 +14,12 @@ Almost 2% of global ecommerce sales flow through Harper Systems, with an average
 - View the frontend at [localhost:9926](http://localhost:9926/)
 - View the data in Harper Studio UI at [localhost:9925](http://localhost:9925/)
 
-## Optional Config: Algolia Search & OpenAI Customized Product Description
+## Optional Config: OpenAI personalization & semantic search
 - Run `cp .env.template .env`
-- Get keys from Algolia and / or OpenAI and add to the .env file
+- Add an `OPENAI_API_KEY` to the `.env` file
 - Restart the application
+
+With a key set, product descriptions are personalized to user traits, and product search becomes semantic: queries are embedded and matched against an HNSW vector index built directly into Harper, with no external search service. Without a key, search falls back to a Harper keyword match. Built-in [Fabric embeddings are coming](https://github.com/HarperFast/harper/issues/510), which will remove the external embedding call entirely.
 
 ## More Information
 For more information about getting started with Harper and building your Next.js applications, see our [getting started guides and documentation](https://www.harperdb.io/development/technologies/next-js).

--- a/app/actions.js
+++ b/app/actions.js
@@ -37,16 +37,27 @@ export async function searchProducts(searchTerm = '') {
 	const term = searchTerm.trim();
 	if (!term) return [];
 
-	const query = EMBEDDINGS_ENABLED
-		? {
-				select: ['id', 'name', 'category', 'price', 'image', 'description', '$distance'],
-				sort: { attribute: 'embedding', target: await embed(term) },
-				limit: 8,
+	let query;
+	if (EMBEDDINGS_ENABLED) {
+		try {
+			const embedding = await embed(term);
+			if (embedding) {
+				query = {
+					select: ['id', 'name', 'category', 'price', 'image', 'description', '$distance'],
+					sort: { attribute: 'embedding', target: embedding },
+					limit: 8,
+				};
 			}
-		: {
-				conditions: [{ attribute: 'name', comparator: 'contains', value: term }],
-				limit: 8,
-			};
+		} catch (error) {
+			console.error('Embedding failed, falling back to keyword search:', error);
+		}
+	}
+	if (!query) {
+		query = {
+			conditions: [{ attribute: 'name', comparator: 'contains', value: term }],
+			limit: 8,
+		};
+	}
 
 	const results = [];
 	for await (const product of Product.search(query)) {

--- a/app/actions.js
+++ b/app/actions.js
@@ -1,7 +1,8 @@
 'use server';
 import { tables } from 'harper';
 const { Product } = tables;
-import { initAlgolia, initOpenai } from '@/lib/utils';
+import { initOpenai } from '@/lib/utils';
+import { embed, EMBEDDINGS_ENABLED } from '@/lib/embeddings';
 
 // Harper DB Server Actions
 export async function listProducts(conditions = {}) {
@@ -26,17 +27,32 @@ export async function updateUserTraits(id = "1", traits) {
 	return 'successfully updated Traits table';
 }
 
-// Algolia Search Server Actions
-const algoliaClient = initAlgolia();
+// Search Server Action (Harper-native)
+//
+// Semantic search when an embedding provider is configured: embed the query and
+// run an HNSW nearest-neighbor search over the products, ranked by similarity.
+// Falls back to a Harper keyword match otherwise, so search works with no keys
+// and no external search service.
 export async function searchProducts(searchTerm = '') {
-	if (algoliaClient) {
-		return await algoliaClient.searchSingleIndex({
-			indexName: 'productdata',
-			searchParams: { query: searchTerm },
-		});
+	const term = searchTerm.trim();
+	if (!term) return [];
+
+	const query = EMBEDDINGS_ENABLED
+		? {
+				select: ['id', 'name', 'category', 'price', 'image', 'description', '$distance'],
+				sort: { attribute: 'embedding', target: await embed(term) },
+				limit: 8,
+			}
+		: {
+				conditions: [{ attribute: 'name', comparator: 'contains', value: term }],
+				limit: 8,
+			};
+
+	const results = [];
+	for await (const product of Product.search(query)) {
+		results.push(product);
 	}
-	// TODO: return harperdb graphql query
-	return [];
+	return results;
 }
 
 // OpenAI Server Actions

--- a/components/control-panel.js
+++ b/components/control-panel.js
@@ -19,7 +19,6 @@ import { getUserTraits, updateUserTraits } from '@/app/actions';
 
 export const ControlPanelContext = createContext({
   aiPersonalizationEnabled: true,
-  // algoliaEnabled: true,
 });
 
 export function ControlPanel() {
@@ -27,7 +26,6 @@ export function ControlPanel() {
   const [traitsReady, setTraitsReady] = useState(null);
   const [traitValue, setTraitValue] = useState('');
   const [aiPersonalizationEnabled, setAiPersonalizationEnabled] = useState(true);
-  // const [algoliaEnabled, setAlgoliaEnabled] = useState(true);
 
 
   useEffect(() => {
@@ -94,14 +92,6 @@ export function ControlPanel() {
                     onClick={() => setAiPersonalizationEnabled(!aiPersonalizationEnabled)}
                   />
                 </div>
-                {/* <div>
-                  <span style={{ paddingRight: 20 }}>Algolia Search Enable</span>
-                  <Switch
-                    text={algoliaEnabled ? 'On' : 'Off'}
-                    checked = {algoliaEnabled}
-                    onClick={() => setAlgoliaEnabled(!algoliaEnabled)}
-                  />
-                </div> */}
               </div>
             </div>
             {/* User traits tied to AI product personalization */}

--- a/components/site-header.js
+++ b/components/site-header.js
@@ -14,11 +14,7 @@ export function SiteHeader() {
   function search(e) {
     // TODO: could debounce for optimization
     searchProducts(e.target.value)
-      .then(res => {
-        if (res?.hits) {
-          setSearchResults(res.hits);
-        }
-      });
+      .then(res => setSearchResults(Array.isArray(res) ? res : []));
   }
 
   return (

--- a/components/site-header.js
+++ b/components/site-header.js
@@ -12,9 +12,12 @@ export function SiteHeader() {
   const [searchResults, setSearchResults] = useState([]);
 
   function search(e) {
-    // TODO: could debounce for optimization
-    searchProducts(e.target.value)
-      .then(res => setSearchResults(Array.isArray(res) ? res : []));
+    const target = e.target;
+    clearTimeout(target.searchTimeout);
+    target.searchTimeout = setTimeout(() => {
+      searchProducts(target.value)
+        .then(res => setSearchResults(Array.isArray(res) ? res : []));
+    }, 300);
   }
 
   return (

--- a/lib/embeddings.js
+++ b/lib/embeddings.js
@@ -1,0 +1,19 @@
+import OpenAI from 'openai';
+
+// Embeddings for semantic product search. Generated via OpenAI when
+// OPENAI_API_KEY is set; Harper stores and searches the vectors with its
+// built-in HNSW index, so the search engine itself is Harper, not an external
+// service. Built-in Fabric embeddings are coming
+// (https://github.com/HarperFast/harper/issues/510), which will move even this
+// step in-process.
+const MODEL = process.env.OPENAI_EMBEDDING_MODEL || 'text-embedding-3-small';
+
+export const EMBEDDINGS_ENABLED = Boolean(process.env.OPENAI_API_KEY);
+
+let client;
+export async function embed(text) {
+	if (!EMBEDDINGS_ENABLED) return null;
+	client ??= new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+	const response = await client.embeddings.create({ model: MODEL, input: text });
+	return response.data[0].embedding;
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,27 +1,16 @@
 import { clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
-import { algoliasearch } from 'algoliasearch';
 import OpenAI from 'openai';
 
 export function cn(...inputs) {
   return twMerge(clsx(inputs));
 }
 
-export const initAlgolia = () => {
-  if (process.env.ALGOLIA_APP_ID && process.env.ALGOLIA_API_KEY) {
-    return algoliasearch(
-      process.env.ALGOLIA_APP_ID,
-      process.env.ALGOLIA_API_KEY,
-    );
-  }
-  return null;
-}
-
 export const initOpenai = () => {
   if (process.env.OPENAI_API_KEY) {
     return new OpenAI({
       apiKey: process.env.OPENAI_API_KEY,
-    });  
+    });
   }
   return null;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@radix-ui/react-slider": "^1.2.0",
         "@radix-ui/react-slot": "^1.1.0",
         "@radix-ui/react-switch": "^1.1.0",
-        "algoliasearch": "^5.20.1",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "harper": "^5.0.10",
@@ -58,201 +57,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@algolia/abtesting": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.18.1.tgz",
-      "integrity": "sha512-aehCadlWOGvrT91KUIZpC0MbB8KBW9yUuvTJFd2xesR7le/IsT4nJUnjCCZ4ZqZCeTcPHPV5mo//fZ5oxcSVYw==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.52.1",
-        "@algolia/requester-browser-xhr": "5.52.1",
-        "@algolia/requester-fetch": "5.52.1",
-        "@algolia/requester-node-http": "5.52.1"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/client-abtesting": {
-      "version": "5.52.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.52.1.tgz",
-      "integrity": "sha512-HmXOGBOAOJPounpBzBpuY0zDYeiCpxgHnQmuA7JO6ScukcBdGp3/XM9zJk5pJx/xNGD68mbPGXWpDxGtl6BwDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.52.1",
-        "@algolia/requester-browser-xhr": "5.52.1",
-        "@algolia/requester-fetch": "5.52.1",
-        "@algolia/requester-node-http": "5.52.1"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/client-analytics": {
-      "version": "5.52.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.52.1.tgz",
-      "integrity": "sha512-5oo4+I8iixie9vXhCyNFCzeIr8pqA3FQ//VsLHTDvZAV4ttYOPGvYHGQq5NSalrLx5Jc3dRro/5uDOlnUMcBJg==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.52.1",
-        "@algolia/requester-browser-xhr": "5.52.1",
-        "@algolia/requester-fetch": "5.52.1",
-        "@algolia/requester-node-http": "5.52.1"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/client-common": {
-      "version": "5.52.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.52.1.tgz",
-      "integrity": "sha512-qCDoZfx5MpX7XQzvQ3bC4tSEMkQWQMaF/ABtLuoze03Y/flR563CCSws02qIJ23oX7lxl92LsilZjINVyTdtLw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/client-insights": {
-      "version": "5.52.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.52.1.tgz",
-      "integrity": "sha512-hnGs0/lsFJ2PWDxNBz7pxreXo/Xz7gxYRcfePBUjsH26ad0kU/sgnVZd9LwWBpsQv65z2jlb5dkyaB9WE9M9FQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.52.1",
-        "@algolia/requester-browser-xhr": "5.52.1",
-        "@algolia/requester-fetch": "5.52.1",
-        "@algolia/requester-node-http": "5.52.1"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/client-personalization": {
-      "version": "5.52.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.52.1.tgz",
-      "integrity": "sha512-2VxxNc/uBysyKvGeBdSM5n9eIDKH8kWD7wd9/yqbJAiVwU4Yv6tU1LSJusHKrXV/aCu1KW7t9Gug9QyeEmtn/Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.52.1",
-        "@algolia/requester-browser-xhr": "5.52.1",
-        "@algolia/requester-fetch": "5.52.1",
-        "@algolia/requester-node-http": "5.52.1"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/client-query-suggestions": {
-      "version": "5.52.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.52.1.tgz",
-      "integrity": "sha512-O6mPtsw3xEfNOe6gWFpYLeAZAIljNa4Hgna3bq15PwyN7nbjTY0wXJFRbzs/0YVf75Br+SbOQUmjKxXYjDiSiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.52.1",
-        "@algolia/requester-browser-xhr": "5.52.1",
-        "@algolia/requester-fetch": "5.52.1",
-        "@algolia/requester-node-http": "5.52.1"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/client-search": {
-      "version": "5.52.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.52.1.tgz",
-      "integrity": "sha512-gA8oJOV1LnQQkDf91iebNnFInHuW0gRPEgLSOQ7EfipCEjYTHm5swm1DlH9H5RaRw4RrHuzHBegnlzc0MAstcg==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.52.1",
-        "@algolia/requester-browser-xhr": "5.52.1",
-        "@algolia/requester-fetch": "5.52.1",
-        "@algolia/requester-node-http": "5.52.1"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/ingestion": {
-      "version": "1.52.1",
-      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.52.1.tgz",
-      "integrity": "sha512-U9zZfc5xIu9wRxZkt+HceJUAD4VKHKbAyLSloJdEyMRmphXeibfrY9cxqIXBcmPeZzGhn3Imb35Dq8l19PkJhw==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.52.1",
-        "@algolia/requester-browser-xhr": "5.52.1",
-        "@algolia/requester-fetch": "5.52.1",
-        "@algolia/requester-node-http": "5.52.1"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/monitoring": {
-      "version": "1.52.1",
-      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.52.1.tgz",
-      "integrity": "sha512-a3SGNceHmkQfq77iG8Ka+w1pvwfZa/0lzEIgse30fL0kD+yKnd/dg0dQvSfFPAEt2f21DMcGkDSSeJlO3KdQjQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.52.1",
-        "@algolia/requester-browser-xhr": "5.52.1",
-        "@algolia/requester-fetch": "5.52.1",
-        "@algolia/requester-node-http": "5.52.1"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/recommend": {
-      "version": "5.52.1",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.52.1.tgz",
-      "integrity": "sha512-z98QEguCFDpxb4S/PyrUK1igqF8tPsdbqOUUO6ON91vJ58w+Gwa6ncrI0oNXSFcrkxA5EqPKPQ2A1PBCn08TYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.52.1",
-        "@algolia/requester-browser-xhr": "5.52.1",
-        "@algolia/requester-fetch": "5.52.1",
-        "@algolia/requester-node-http": "5.52.1"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/requester-browser-xhr": {
-      "version": "5.52.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.52.1.tgz",
-      "integrity": "sha512-CI7+/0I11QeZM59Uc8whd2or0kqzFVjpaPn9Qpwll/krHcBAxk24WkAQ6WX+IwDVMfpont4YGbKwAmCre3vE8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.52.1"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/requester-fetch": {
-      "version": "5.52.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.52.1.tgz",
-      "integrity": "sha512-S6bDuw9byfOvm3T71cgdoZgrgnZq6hpdMLkx52Louh57nUAmvGQESz2aojOynQHjbTiV55smvAFbgn0qT4tJrg==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.52.1"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/requester-node-http": {
-      "version": "5.52.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.52.1.tgz",
-      "integrity": "sha512-tqZXM+54rWo4mk5jL5Z/flE11nPmNEdXwFBM5py9DkOmbjeCNemfVd45FyM97XdzfZ0dl9uOJC6PYn1FpkeyQg==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.52.1"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -475,7 +279,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1043.0.tgz",
       "integrity": "sha512-QrDh9PACpmijOgbVnvQIvoWFZcMEBoGw0qiQRfGvsUEcB1JPCS2U5R0irB4XQSmsBlQUNlNeXVfpx3JI++NqrA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -4610,6 +4413,70 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.4.tgz",
@@ -4924,7 +4791,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.14.tgz",
       "integrity": "sha512-4zXMWD91vBLGRtHK3YbIoFMia+1nqEz72coM42C5ETjnNCa/heoj7NT1G67iAfOqMmcfhuCZ4uNpyz8EjlAejw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.8.0"
       }
@@ -4935,7 +4801,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4946,7 +4811,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -5025,31 +4889,6 @@
       },
       "engines": {
         "node": ">=15"
-      }
-    },
-    "node_modules/algoliasearch": {
-      "version": "5.52.1",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.52.1.tgz",
-      "integrity": "sha512-fHA8+kXTbjagw3jkLiaS7KKrH8qe2DyOsiUhGlN4cdT77PEsfqXZl7ewDk1hsg+pJnPlnE50XtLxjR91iJOpmg==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/abtesting": "1.18.1",
-        "@algolia/client-abtesting": "5.52.1",
-        "@algolia/client-analytics": "5.52.1",
-        "@algolia/client-common": "5.52.1",
-        "@algolia/client-insights": "5.52.1",
-        "@algolia/client-personalization": "5.52.1",
-        "@algolia/client-query-suggestions": "5.52.1",
-        "@algolia/client-search": "5.52.1",
-        "@algolia/ingestion": "1.52.1",
-        "@algolia/monitoring": "1.52.1",
-        "@algolia/recommend": "5.52.1",
-        "@algolia/requester-browser-xhr": "5.52.1",
-        "@algolia/requester-fetch": "5.52.1",
-        "@algolia/requester-node-http": "5.52.1"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
       }
     },
     "node_modules/amaro": {
@@ -6700,7 +6539,6 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.0.tgz",
       "integrity": "sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -8166,7 +8004,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-15.4.11.tgz",
       "integrity": "sha512-IJRyXal45mIsshZI5XJne/intjusslUP1F+FHVBIyMGEqbYtIq1Irdx5vdWBBg58smviPDycmDeV6txsfkv1RQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "15.4.11",
         "@swc/helpers": "0.5.15",
@@ -9121,7 +8958,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9131,7 +8967,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10452,7 +10287,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@radix-ui/react-slider": "^1.2.0",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-switch": "^1.1.0",
-    "algoliasearch": "^5.20.1",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "harper": "^5.0.10",

--- a/resources.js
+++ b/resources.js
@@ -4,9 +4,15 @@
 
 import { tables } from 'harper';
 import productdata from "./productdata.json" with { type: "json" };
+import { embed, EMBEDDINGS_ENABLED } from './lib/embeddings.js';
 
 // product table seed data
 for (const product of productdata) {
+	// When an embedding provider is configured, embed each product so it can be
+	// found by meaning via Harper's HNSW vector index. Skipped otherwise.
+	if (EMBEDDINGS_ENABLED) {
+		product.embedding = await embed(`${product.name}. ${product.description}`);
+	}
 	tables.Product.put(product);
 }
 

--- a/resources.js
+++ b/resources.js
@@ -7,12 +7,14 @@ import productdata from "./productdata.json" with { type: "json" };
 import { embed, EMBEDDINGS_ENABLED } from './lib/embeddings.js';
 
 // product table seed data
+if (EMBEDDINGS_ENABLED) {
+	await Promise.all(
+		productdata.map(async (product) => {
+			product.embedding = await embed(`${product.name}. ${product.description}`);
+		})
+	);
+}
 for (const product of productdata) {
-	// When an embedding provider is configured, embed each product so it can be
-	// found by meaning via Harper's HNSW vector index. Skipped otherwise.
-	if (EMBEDDINGS_ENABLED) {
-		product.embedding = await embed(`${product.name}. ${product.description}`);
-	}
 	tables.Product.put(product);
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -15,6 +15,10 @@ type Product @table @export {
   description: String
   features: [String]
   specs: Specs
+  # Semantic-search vector. Populated at seed time when an embedding provider
+  # (OPENAI_API_KEY) is configured; see lib/embeddings.js. Harper indexes and
+  # searches it natively with HNSW, replacing the external search service.
+  embedding: [Float] @indexed(type: "HNSW", distance: "cosine")
 }
 
 type Traits @table @export {


### PR DESCRIPTION
## Summary

The template demonstrated product search by calling **Algolia**, an external search engine, while sitting on Harper's own vector search. This moves search into Harper: products are embedded and matched against a built-in **HNSW** index, so the search engine itself is Harper, not a competitor's service.

- **Remove Algolia entirely**: the `algoliasearch` dependency, `initAlgolia`, the `ALGOLIA_*` env vars, and the dead Algolia toggle in the admin panel.
- **Semantic search**: `Product.embedding` is `@indexed(type: "HNSW", distance: "cosine")`; products are embedded at seed time and `searchProducts` embeds the query and runs a vector nearest-neighbor search ranked by `$distance`.
- **Works with no keys**: when `OPENAI_API_KEY` is unset, search falls back to a Harper keyword match, so the template runs out of the box with zero external services.
- Embeddings are generated via OpenAI for now; Harper does the indexing, ranking, and serving. Built-in [Fabric embeddings (harper#510)](https://github.com/HarperFast/harper/issues/510) will move even the embedding step in-process.

## Why

Shipping a competitor's search engine as our ecommerce template's search story undercuts the pitch. Harper has had HNSW vector search for a while; this template should show it.

## Test plan

- [x] No `algolia` references remain in source; `package-lock.json` regenerated (algoliasearch + transitive deps removed)
- [x] `node --check` passes on all changed modules
- [ ] `npm i && npm run dev`, verify search returns results (keyword fallback with no key)
- [ ] With `OPENAI_API_KEY` set, verify seed embeds products and search returns semantically-ranked matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)