### PR TITLE
fix: restore experimental.cpus:1 and outputFileTracingRoot dropped in PRs #6/#8

### DIFF
--- a/integrationTests/routes.helpers.test.mjs
+++ b/integrationTests/routes.helpers.test.mjs
@@ -151,6 +151,25 @@ test('products listing filter/sort logic filters by category, price range, and s
 	assert.deepEqual(none, [], 'no matches must yield an empty array');
 });
 
+// --- Build worker serialisation (issue #13 regression guard) ---
+
+test('next.config.js serialises build workers to prevent concurrent RocksDB lock contention', () => {
+	const config = _require(path.join(ROOT, 'next.config.js'));
+	assert.strictEqual(
+		config.experimental?.cpus,
+		1,
+		'experimental.cpus must be 1: build workers each require() the externalized harper module and ' +
+			'contend for RocksDB exclusive lock on appCache; without serialisation the build fails with ' +
+			'"Operation not permitted opening database appCache" (regressed in PRs #6/#8, fixed in #13)'
+	);
+	assert.strictEqual(
+		config.outputFileTracingRoot,
+		path.resolve(ROOT),
+		'outputFileTracingRoot must be set to the project root to silence Next.js workspace-root warning ' +
+			'(was dropped alongside experimental.cpus in the same restructure)'
+	);
+});
+
 // --- Early Hints origin contract (issue #8) ---
 
 test('next.config.js keeps images unoptimized and never emits Link or Server-Timing from headers()', async () => {

--- a/next.config.js
+++ b/next.config.js
@@ -12,8 +12,14 @@ const nextConfig = {
 	// itself and headers() must never set or overwrite `Link` or
 	// `Server-Timing` — only Cache-Control. See docs/early-hints-manifest.md.
 	images: { unoptimized: true },
+	outputFileTracingRoot: __dirname,
 	cacheHandler: CACHE_HANDLER_PATH,
 	cacheMaxMemorySize: 0,
+	// Build workers each load the (externalized) harper module, and concurrent
+	// processes contend for the same database lock. One worker serializes
+	// page-data collection and static generation so `next build` works against
+	// a local Harper root.
+	experimental: { cpus: 1 },
 	// Deterministic per-route Cache-Control for the cacheable SSR/ISR routes
 	// (issue #6) and the never-cache personalized route (issue #7).
 	async headers() {


### PR DESCRIPTION
## Summary

`npm run build` was failing with `IO error: Operation not permitted opening database appCache` during Next.js's \"Collecting page data\" phase for the `/`, `/products`, `/products/[id]`, and `/products/[id]/personalized` routes.

**Root cause:** Two lines were present in `next.config.js` in PR #5 but were accidentally dropped when the file was restructured in PRs #6 and #8:

1. **`experimental: { cpus: 1 }`** — the critical one. Pages that import `harper` (directly or through server actions) cause each Next.js build worker process to independently try to acquire RocksDB's exclusive lock on `harper/database/appCache`. Without serialisation, concurrent workers race to rename the database LOG file and all but one fail. The original PR #5 author added this with an explicit comment explaining exactly this lock-contention problem.

2. **`outputFileTracingRoot: __dirname`** — suppresses Next.js's \"inferred workspace root\" warning triggered by multiple `package-lock.json` files.

## Test plan

- [ ] Run `npm run build` — should complete without database errors
- [ ] Confirm the `⚠ Warning: Next.js inferred your workspace root` warning is gone
- [ ] Run `npm run test:unit` and `npm run test:integration` — should still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)