### PR TITLE
feat: demo cart, personalization fixes, and Server-Timing fallback

### DIFF
--- a/app/actions.js
+++ b/app/actions.js
@@ -25,7 +25,8 @@ export async function getProduct(id) {
 }
 
 export async function getUserTraits(id = "1") {
-	return globalThis.tables?.Traits.get(id)?.traits ?? [];
+	const record = await globalThis.tables?.Traits.get(id);
+	return record?.traits ? [...record.traits] : [];
 }
 
 export async function updateUserTraits(id = "1", traits) {
@@ -75,8 +76,8 @@ export async function searchProducts(searchTerm = '') {
 }
 
 // OpenAI Server Actions
-const openaiClient = initOpenai();
 export async function customizeProductDescription(userTraits = [], productDescription) {
+	const openaiClient = initOpenai();
 	if (openaiClient) {
 		const prompt = `Given that a person has the following traits: ${userTraits.join(', ')} 
 			can you rewrite the following product description passage for someone like this: ${productDescription} without using exclamation points?

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,7 +1,9 @@
 import './globals.css';
 import { Inter } from 'next/font/google';
 import { SiteHeader } from '@/components/site-header';
-import { ControlPanel } from '@/components/control-panel';
+import { ControlPanel, ControlPanelProvider } from '@/components/control-panel';
+import { CartProvider } from '@/lib/cart-context';
+import { CartDrawer } from '@/components/cart-drawer';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -12,9 +14,14 @@ export default function RootLayout({ children }) {
         <title>Harper Digital Commerce</title>
       </head>
       <body className={inter.className}>
-        <SiteHeader />
-        {children}
-        <ControlPanel />
+        <ControlPanelProvider>
+          <CartProvider>
+            <SiteHeader />
+            {children}
+            <ControlPanel />
+            <CartDrawer />
+          </CartProvider>
+        </ControlPanelProvider>
       </body>
     </html>
   );

--- a/app/products/[id]/product-page.js
+++ b/app/products/[id]/product-page.js
@@ -9,6 +9,7 @@ import { notFound } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { ControlPanelContext } from "@/components/control-panel";
+import { useCart } from "@/lib/cart-context";
 import {
   listProducts,
   customizeProductDescription,
@@ -21,6 +22,7 @@ import {
 export default function ProductPage({ id, product, serverPersonalized = false }) {
   if (!product) notFound();
   const { aiPersonalizationEnabled } = useContext(ControlPanelContext);
+  const { addToCart } = useCart();
   const [productDescReady, setProductDescReady] = useState(false);
   const [recommendationsReady, setRecommendationsReady] = useState(false);
   const [relatedProducts, setRelatedProducts] = useState([]);
@@ -116,7 +118,11 @@ export default function ProductPage({ id, product, serverPersonalized = false })
             <p className="text-muted-foreground" style={{ minHeight: 100 }}>{renderProductDescription()}</p>
 
             <div className="flex items-center space-x-4">
-              <Button size="lg" className="flex-1">
+              <Button
+                size="lg"
+                className="flex-1"
+                onClick={() => addToCart({ id, name: product.name, price: product.price, image: product.image })}
+              >
                 <ShoppingBag className="mr-2 h-5 w-5" />
                 Add to Cart
               </Button>

--- a/components/cart-drawer.js
+++ b/components/cart-drawer.js
@@ -1,0 +1,67 @@
+'use client';
+
+import { X, Trash2 } from 'lucide-react';
+import { Button } from './ui/button';
+import { useCart } from '@/lib/cart-context';
+
+export function CartDrawer() {
+  const { items, isOpen, closeCart, removeFromCart, total } = useCart();
+
+  if (!isOpen) return null;
+
+  return (
+    <>
+      <div className="fixed inset-0 z-50 bg-black/50" onClick={closeCart} />
+      <div className="fixed right-0 top-0 z-50 flex h-full w-80 flex-col bg-background shadow-xl">
+        <div className="flex items-center justify-between border-b px-4 py-4">
+          <h2 className="text-lg font-semibold">
+            Cart {items.length > 0 && `(${items.length})`}
+          </h2>
+          <Button size="icon" variant="ghost" onClick={closeCart}>
+            <X className="h-5 w-5" />
+          </Button>
+        </div>
+
+        <div className="flex-1 space-y-4 overflow-y-auto px-4 py-4">
+          {items.length === 0 ? (
+            <p className="py-8 text-center text-muted-foreground">Your cart is empty</p>
+          ) : (
+            items.map((item) => (
+              <div key={item.id} className="flex items-center gap-3">
+                <img
+                  src={item.image}
+                  alt={item.name}
+                  className="h-16 w-16 rounded object-cover"
+                />
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-medium">{item.name}</p>
+                  <p className="text-sm text-muted-foreground">
+                    ${item.price.toFixed(2)} &times; {item.quantity}
+                  </p>
+                </div>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  onClick={() => removeFromCart(item.id)}
+                  aria-label={`Remove ${item.name}`}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
+            ))
+          )}
+        </div>
+
+        <div className="border-t px-4 py-4">
+          <div className="mb-4 flex justify-between text-base font-semibold">
+            <span>Total</span>
+            <span>${total.toFixed(2)}</span>
+          </div>
+          <Button className="w-full" size="lg" disabled={items.length === 0}>
+            Checkout
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/components/control-panel.js
+++ b/components/control-panel.js
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, createContext } from "react";
+import { useState, useEffect, createContext, useContext } from "react";
 import Image from "next/image";
 import {
   Dialog,
@@ -19,14 +19,23 @@ import { getUserTraits, updateUserTraits } from '@/app/actions';
 
 export const ControlPanelContext = createContext({
   aiPersonalizationEnabled: true,
+  setAiPersonalizationEnabled: () => {},
 });
 
+export function ControlPanelProvider({ children }) {
+  const [aiPersonalizationEnabled, setAiPersonalizationEnabled] = useState(true);
+  return (
+    <ControlPanelContext.Provider value={{ aiPersonalizationEnabled, setAiPersonalizationEnabled }}>
+      {children}
+    </ControlPanelContext.Provider>
+  );
+}
+
 export function ControlPanel() {
+  const { aiPersonalizationEnabled, setAiPersonalizationEnabled } = useContext(ControlPanelContext);
   const [traits, setTraits] = useState([]);
   const [traitsReady, setTraitsReady] = useState(null);
   const [traitValue, setTraitValue] = useState('');
-  const [aiPersonalizationEnabled, setAiPersonalizationEnabled] = useState(true);
-
 
   useEffect(() => {
     const fetchData = async () => {
@@ -39,7 +48,6 @@ export function ControlPanel() {
         console.error('Error fetching data:', error);
       }
     };
-    // Call fetchData when the component mounts
     fetchData();
   }, []);
 
@@ -47,8 +55,6 @@ export function ControlPanel() {
     const id = e.target.id;
     const arrayIndex = Number(id.split('-')[1]);
     const newTraits = traits.filter((_, i) => i !== arrayIndex);
-
-    // server action - update harper DB
     updateUserTraits("1", newTraits);
     setTraits(newTraits);
   }
@@ -58,81 +64,75 @@ export function ControlPanel() {
   }
 
   function handleAddTrait() {
-    // server action - update harper DB
     updateUserTraits("1", [traitValue, ...traits]);
     setTraitValue('');
     setTraits([traitValue, ...traits]);
   }
 
   return (
-    <ControlPanelContext.Provider value={{ aiPersonalizationEnabled }}>
-      <Dialog>
-        <DialogTrigger>
-          <div className="control-panel">
-            <Image
-              className="control-panel-img"
-              src={harper_logo}
-              alt='harper logo'
-            />
-            Admin
-          </div>
-        </DialogTrigger>
-        <DialogPortal>
-          <DialogContent>
-            <DialogTitle>Application Admin Panel</DialogTitle>
-            <DialogDescription>Customize app behavior for demo purposes</DialogDescription>
-            <div>
-              <h3>Demo Features</h3>
-              <div style={{ fontSize: 14, color: 'gray' }}>
-                <div>
-                  <span style={{ paddingRight: 20 }}>OpenAI Product Personalization</span>
-                  <Switch
-                    text={aiPersonalizationEnabled ? 'On' : 'Off'}
-                    checked = {aiPersonalizationEnabled}
-                    onClick={() => setAiPersonalizationEnabled(!aiPersonalizationEnabled)}
-                  />
-                </div>
+    <Dialog>
+      <DialogTrigger>
+        <div className="control-panel">
+          <Image
+            className="control-panel-img"
+            src={harper_logo}
+            alt='harper logo'
+          />
+          Admin
+        </div>
+      </DialogTrigger>
+      <DialogPortal>
+        <DialogContent>
+          <DialogTitle>Application Admin Panel</DialogTitle>
+          <DialogDescription>Customize app behavior for demo purposes</DialogDescription>
+          <div>
+            <h3>Demo Features</h3>
+            <div style={{ fontSize: 14, color: 'gray' }}>
+              <div>
+                <span style={{ paddingRight: 20 }}>OpenAI Product Personalization</span>
+                <Switch
+                  text={aiPersonalizationEnabled ? 'On' : 'Off'}
+                  checked={aiPersonalizationEnabled}
+                  onClick={() => setAiPersonalizationEnabled(!aiPersonalizationEnabled)}
+                />
               </div>
             </div>
-            {/* User traits tied to AI product personalization */}
-            <>
-              <h3>Current Traits</h3>
-              {aiPersonalizationEnabled ?
-                (
-                  <>
-                    <div style={{ fontSize: 14, color: 'gray' }}>
-                      [
-                      {traitsReady && traits ? traits.map((trait, i) => (
-                        <span key={`trait-${i}-${trait}`}>
-                          {trait}
-                          <Button
-                            size="sm"
-                            variant="ghost"
-                            id={`btntraitid-${i}`}
-                            onClick={handleDeleteTrait}
-                          >
-                            <Trash className="h-3 w-3" color="red" id={`icntraitid-${i}`} />
-                          </Button>
-                          {i === traits.length-1 ? '' : ', '}
-                        </span>
-                      )) : 'Loading'}
-                      ]
-                    </div>
-                    <Input onChange={handleTextChange} value={traitValue} />
-                    <Button size="lg" variant="default" style={{ backgroundColor: '#262626' }} onClick={handleAddTrait}>
-                      Add Trait
-                    </Button>
-                  </>
-                ) : (
-                  <div style={{ fontSize: 14, color: 'gray', minHeight: 140 }}>
-                    Featured disabled
-                  </div>
-                )
-              }
-            </>
-          </DialogContent>
-        </DialogPortal>
-      </Dialog>
-    </ControlPanelContext.Provider>
+          </div>
+          <>
+            <h3>Current Traits</h3>
+            {aiPersonalizationEnabled ? (
+              <>
+                <div style={{ fontSize: 14, color: 'gray' }}>
+                  [
+                  {traitsReady && traits ? traits.map((trait, i) => (
+                    <span key={`trait-${i}-${trait}`}>
+                      {trait}
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        id={`btntraitid-${i}`}
+                        onClick={handleDeleteTrait}
+                      >
+                        <Trash className="h-3 w-3" color="red" id={`icntraitid-${i}`} />
+                      </Button>
+                      {i === traits.length - 1 ? '' : ', '}
+                    </span>
+                  )) : 'Loading'}
+                  ]
+                </div>
+                <Input onChange={handleTextChange} value={traitValue} />
+                <Button size="lg" variant="default" style={{ backgroundColor: '#262626' }} onClick={handleAddTrait}>
+                  Add Trait
+                </Button>
+              </>
+            ) : (
+              <div style={{ fontSize: 14, color: 'gray', minHeight: 140 }}>
+                Featured disabled
+              </div>
+            )}
+          </>
+        </DialogContent>
+      </DialogPortal>
+    </Dialog>
   );
 }

--- a/components/site-header.js
+++ b/components/site-header.js
@@ -7,9 +7,11 @@ import { Button } from "./ui/button";
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuPortal, DropdownMenuContent } from "./ui/dropdown-menu";
 import { Input } from "./ui/input";
 import { searchProducts } from '@/app/actions';
+import { useCart } from '@/lib/cart-context';
 
 export function SiteHeader() {
   const [searchResults, setSearchResults] = useState([]);
+  const { itemCount, openCart } = useCart();
 
   function search(e) {
     const target = e.target;
@@ -34,9 +36,8 @@ export function SiteHeader() {
           </Link>
 
           <DropdownMenu>
-
             <DropdownMenuTrigger asChild>
-              <Button size="icon" variant="ghost" onClick={() => {}}>
+              <Button size="icon" variant="ghost">
                 <Search className="h-5 w-5" />
               </Button>
             </DropdownMenuTrigger>
@@ -48,15 +49,11 @@ export function SiteHeader() {
                   <Input type="text" onChange={search} />
                 </div>
                 <div style={{ paddingTop: 10, paddingBottom: 10 }}>
-                  {searchProducts && searchResults.map(res => (
+                  {searchResults.map(res => (
                     <Link key={`product-${res.id}`} href={`/products/${res.id}`}>
                       <div style={{ paddingTop: 5, paddingBottom: 5 }}>
-                        <div>
-                          {res.name}
-                        </div>
-                        <div style={{ color: 'gray', fontSize: 12 }}>
-                          {res.description}
-                        </div>
+                        <div>{res.name}</div>
+                        <div style={{ color: 'gray', fontSize: 12 }}>{res.description}</div>
                       </div>
                     </Link>
                   ))}
@@ -65,8 +62,13 @@ export function SiteHeader() {
             </DropdownMenuPortal>
           </DropdownMenu>
 
-          <Button size="icon" variant="ghost">
+          <Button size="icon" variant="ghost" onClick={openCart} aria-label="Open cart" className="relative">
             <ShoppingBag className="h-5 w-5" />
+            {itemCount > 0 && (
+              <span className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full bg-primary text-[10px] font-bold text-primary-foreground">
+                {itemCount > 9 ? '9+' : itemCount}
+              </span>
+            )}
           </Button>
         </nav>
       </div>

--- a/integrationTests/serverTiming.test.mjs
+++ b/integrationTests/serverTiming.test.mjs
@@ -82,14 +82,17 @@ void suite('server-timing middleware (server-timing/extension.mjs)', () => {
 		strictEqual(response.headers.get('server-timing'), 'hdb;dur=1.52, decision;dur=7.3');
 	});
 
-	void test('leaves headers untouched when no duration was recorded', async () => {
+	void test('falls back to elapsed request time when no duration was explicitly recorded', async () => {
 		const makeReq = createListener();
 		const { request, listener } = makeReq();
 		const response = createMockResponse('hdb;dur=3.1');
 
 		await listener(request, async () => response);
 
-		strictEqual(response.headers.get('server-timing'), 'hdb;dur=3.1');
+		// Upstream hdb segment must be preserved and decision;dur must be appended
+		// (elapsed fallback — exact value is timing-dependent so we pattern-check).
+		const st = response.headers.get('server-timing');
+		ok(st?.startsWith('hdb;dur=3.1, decision;dur='), `expected elapsed fallback, got: ${st}`);
 	});
 
 	void test('returns the response from the next layer unchanged', async () => {

--- a/lib/cart-context.js
+++ b/lib/cart-context.js
@@ -1,0 +1,74 @@
+'use client';
+
+import { createContext, useContext, useState, useEffect, useCallback } from 'react';
+
+export const CartContext = createContext({
+  items: [],
+  isOpen: false,
+  itemCount: 0,
+  total: 0,
+  addToCart: () => {},
+  removeFromCart: () => {},
+  clearCart: () => {},
+  openCart: () => {},
+  closeCart: () => {},
+});
+
+export function CartProvider({ children }) {
+  const [items, setItems] = useState([]);
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem('harper-cart');
+      if (saved) setItems(JSON.parse(saved));
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('harper-cart', JSON.stringify(items));
+    } catch {}
+  }, [items]);
+
+  const addToCart = useCallback((product) => {
+    setItems((prev) => {
+      const existing = prev.find((item) => item.id === product.id);
+      if (existing) {
+        return prev.map((item) =>
+          item.id === product.id ? { ...item, quantity: item.quantity + 1 } : item
+        );
+      }
+      return [...prev, { id: product.id, name: product.name, price: product.price, image: product.image, quantity: 1 }];
+    });
+  }, []);
+
+  const removeFromCart = useCallback((id) => {
+    setItems((prev) => prev.filter((item) => item.id !== id));
+  }, []);
+
+  const clearCart = useCallback(() => setItems([]), []);
+
+  const itemCount = items.reduce((sum, item) => sum + item.quantity, 0);
+  const total = items.reduce((sum, item) => sum + item.price * item.quantity, 0);
+
+  return (
+    <CartContext.Provider value={{
+      items,
+      isOpen,
+      itemCount,
+      total,
+      addToCart,
+      removeFromCart,
+      clearCart,
+      openCart: () => setIsOpen(true),
+      closeCart: () => setIsOpen(false),
+    }}>
+      {children}
+    </CartContext.Provider>
+  );
+}
+
+export function useCart() {
+  return useContext(CartContext);
+}

--- a/resources.js
+++ b/resources.js
@@ -31,6 +31,4 @@ const CACHE_RULES = [
 	{ id: 'listing', description: 'Products listing', priority: 30, pathPatterns: ['^/products$'], groupCode: 'listing' },
 	{ id: 'home', description: 'Home', priority: 40, pathPatterns: ['^/$'], groupCode: 'home' },
 ];
-for (const rule of CACHE_RULES) {
-	databases.appCache.CacheRules.put(rule);
-}
+await Promise.all(CACHE_RULES.map((rule) => databases.appCache.CacheRules.put(rule)));

--- a/server-timing/extension.mjs
+++ b/server-timing/extension.mjs
@@ -6,23 +6,27 @@
  * before calling next(). The lib accessor (lib/server-timing.mjs) finds this
  * store via Harper's getContext(), which returns the request object because
  * Harper's transaction() stores the request as its own ALS context value.
- * Both sides hold a reference to the same store{} object, so the timing
- * written during the render is readable in the middleware after next() returns.
  *
- * `globalThis.harper.getContext` (not `globalThis.getContext`) is the correct
- * path inside Harper VM-sandboxed component contexts: getContext lives in the
- * `harper` named export, not as a bare top-level global.
+ * ALS propagation caveat: React's App Router breaks the async chain when it
+ * takes over scheduling, so getContext() returns null inside Next.js server
+ * components and recordDecisionDuration() becomes a no-op for those handlers.
+ * When store.decisionDur is not set by the time the response returns, the
+ * middleware falls back to the total elapsed time for the request. For the
+ * personalized route that time is dominated by the OpenAI call, making it a
+ * useful approximation; cached routes will show a few ms.
  */
 export function start(options) {
 	options.server.http((request, next) => {
 		const store = {};
 		request.__serverTimingStore = store;
+		const started = performance.now();
 
 		return (async () => {
 			const response = await next(request);
 			try {
-				if (store.decisionDur != null && response?.headers?.append) {
-					response.headers.append('Server-Timing', `decision;dur=${Number(store.decisionDur).toFixed(1)}`);
+				if (response?.headers?.append) {
+					const dur = store.decisionDur ?? (performance.now() - started);
+					response.headers.append('Server-Timing', `decision;dur=${Number(dur).toFixed(1)}`);
 				}
 			} catch {
 				// Timing instrumentation must never break the response.


### PR DESCRIPTION
## Summary

Four independent fixes on this branch, addressed in order as bugs were discovered during testing.

---

### 1. Minimal demo cart

A client-side, localStorage-backed cart usable across page navigations.

| File | Change |
|------|--------|
| `lib/cart-context.js` | new — `CartContext`, `CartProvider`, `useCart`; item list, derived `itemCount`/`total`, `openCart`/`closeCart`, persisted to `localStorage` |
| `components/cart-drawer.js` | new — right-side fixed overlay; item list with name, price × quantity, per-item remove, and cart total; backdrop click closes |
| `components/site-header.js` | cart icon wired to `openCart()`; badge shows `itemCount` when > 0 (capped at 9+) |
| `app/products/[id]/product-page.js` | Add to Cart button calls `addToCart({ id, name, price, image })` |
| `app/layout.js` | wrap body with `CartProvider`; render `CartDrawer` at root |

---

### 2. ControlPanelContext propagation fix

`ControlPanelContext.Provider` was rendered inside `<ControlPanel>`, which appears **after** `{children}` in the layout. Product pages consumed the context's default value (`aiPersonalizationEnabled: true`, non-settable) regardless of the admin panel toggle.

- Extracted `ControlPanelProvider` from `control-panel.js` to hold `aiPersonalizationEnabled` state and `setAiPersonalizationEnabled`
- `ControlPanel` UI now consumes the context instead of owning the state
- `app/layout.js` wraps the full app tree in `ControlPanelProvider`

The admin panel toggle now correctly enables/disables client-side personalization on product pages.

---

### 3. Personalization runtime fixes (`app/actions.js`)

Two bugs prevented the `/products/[id]/personalized` server-side route from changing the description:

**`getUserTraits` missing `await`** — Harper 5 `table.get()` is a thenable. Accessing `.traits` on the unresolved record returns `undefined` synchronously, so the `?? []` fallback always fired. The personalized page checks `Array.isArray(traits) && traits.length` before calling OpenAI — this silently skipped the call with no error logged.  
Fix: `await` the `get()` call; spread into a plain array to guarantee `Array.isArray()` returns `true`.

**Module-level `openaiClient`** — `initOpenai()` was called at module-evaluation time, before the `.env` file is necessarily in scope within Harper's VM context.  
Fix: moved inside `customizeProductDescription()` so `OPENAI_API_KEY` is read at call time.

---

### 4. CacheRules race condition (`resources.js`)

`databases.appCache.CacheRules.put()` calls were fire-and-forget. On Node 24 (and intermittently on earlier versions), Harper begins serving requests before those writes flush. The cache handler finds an empty CacheRules table on the first request, the `bypassCache: true` rule for `/products/[id]/personalized` is missing, the response is cached, and every subsequent request serves the stale cached version instantly.

This same race was fixed in `integrationTests/fixture/resources.js` in commit `2a9e992` but was not applied to the production file.  
Fix: `await Promise.all(CACHE_RULES.map(...))` — matches the fixture.

---

### 5. Server-Timing header fallback (`server-timing/extension.mjs`)

React App Router breaks the Node.js `AsyncLocalStorage` chain when it takes over async scheduling. `globalThis.harper.getContext()` returns `null` inside Next.js server components, making `recordDecisionDuration()` a no-op — so `decision;dur` never appeared on any Next.js-rendered route.

Fix: when `store.decisionDur` is not set explicitly, fall back to the total elapsed request time. For the personalized route that time is dominated by the OpenAI call and serves as a useful approximation; cached routes show a few ms. Unit test updated to assert the new always-emit behaviour.

---

## Test plan

- [ ] Add to Cart increments the badge; cart drawer shows item name, price × qty, total; remove works; cart survives page refresh (localStorage)
- [ ] Admin panel personalization toggle correctly enables/disables the client-side description rewrite on `/products/[id]` (requires `OPENAI_API_KEY`)
- [ ] `/products/[id]/personalized` shows a different description than `/products/[id]` (requires `OPENAI_API_KEY`)
- [ ] `Server-Timing: decision;dur=<ms>` header appears on all routes; value is larger on the personalized route
- [ ] `npm run test:unit` — 27/27 pass
- [ ] `npm run build` — completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)