### PR TITLE
feat: working search — serialize results, Enter navigation, vector/keyword fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ update-plan.md
 /integrationTests/fixture/node_modules/server-timing/extension.mjs
 
 # dependencies
-/node_modules
+**/node_modules
 /.pnp
 .pnp.js
 

--- a/app/actions.js
+++ b/app/actions.js
@@ -72,7 +72,9 @@ export async function searchProducts(searchTerm = '') {
 	for await (const product of globalThis.tables.Product.search(query)) {
 		results.push(product);
 	}
-	return results;
+	// JSON round-trip converts Harper Records to plain objects so callers
+	// receive standard {id, name, price, ...} shapes via server-action RPC.
+	return JSON.parse(JSON.stringify(results));
 }
 
 // OpenAI Server Actions

--- a/app/actions.js
+++ b/app/actions.js
@@ -46,35 +46,39 @@ export async function searchProducts(searchTerm = '') {
 	const term = searchTerm.trim();
 	if (!term) return [];
 
-	let query;
+	// Vector search: use HNSW nearest-neighbour when embeddings are available.
+	// Falls back to keyword search if the API call fails or the HNSW index is
+	// empty (products seeded before OPENAI_API_KEY was in process.env).
 	if (EMBEDDINGS_ENABLED) {
 		try {
 			const embedding = await embed(term);
 			if (embedding) {
-				query = {
+				const vectorResults = [];
+				for await (const product of globalThis.tables.Product.search({
 					select: ['id', 'name', 'category', 'price', 'image', 'description', '$distance'],
 					sort: { attribute: 'embedding', target: embedding },
 					limit: 8,
-				};
+				})) {
+					vectorResults.push(product);
+				}
+				if (vectorResults.length > 0) {
+					return JSON.parse(JSON.stringify(vectorResults));
+				}
 			}
 		} catch (error) {
-			console.error('Embedding failed, falling back to keyword search:', error);
+			console.error('Vector search failed, falling back to keyword search:', error);
 		}
 	}
-	if (!query) {
-		query = {
-			conditions: [{ attribute: 'name', comparator: 'contains', value: term }],
-			limit: 8,
-		};
-	}
 
-	const results = [];
-	for await (const product of globalThis.tables.Product.search(query)) {
-		results.push(product);
+	// Keyword fallback: case-sensitive substring match on name.
+	const keywordResults = [];
+	for await (const product of globalThis.tables.Product.search({
+		conditions: [{ attribute: 'name', comparator: 'contains', value: term }],
+		limit: 8,
+	})) {
+		keywordResults.push(product);
 	}
-	// JSON round-trip converts Harper Records to plain objects so callers
-	// receive standard {id, name, price, ...} shapes via server-action RPC.
-	return JSON.parse(JSON.stringify(results));
+	return JSON.parse(JSON.stringify(keywordResults));
 }
 
 // OpenAI Server Actions

--- a/app/products/page.js
+++ b/app/products/page.js
@@ -1,11 +1,17 @@
+import { Suspense } from "react";
 import { listProducts } from "@/app/actions";
 import ProductsBrowser from "./products-browser";
 
 // ISR: server-render the listing (product grid in the initial HTML), cache it
 // via the Harper cache handler, and regenerate at most every 60 seconds.
+// ProductsBrowser uses useSearchParams() which requires a Suspense boundary.
 export const revalidate = 60;
 
 export default async function ProductsPage() {
   const products = JSON.parse(await listProducts());
-  return <ProductsBrowser initialProducts={products} />;
+  return (
+    <Suspense fallback={<div className="container mx-auto px-4 py-8 text-muted-foreground">Loading…</div>}>
+      <ProductsBrowser initialProducts={products} />
+    </Suspense>
+  );
 }

--- a/app/products/products-browser.js
+++ b/app/products/products-browser.js
@@ -11,21 +11,66 @@ import {
 } from "@/components/ui/select";
 import { Slider } from "@/components/ui/slider";
 import Link from "next/link";
-import { useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState, useEffect } from "react";
 import { filterProducts } from "./filter-products.mjs";
+import { searchProducts } from "@/app/actions";
 
 // Interactive listing UI (filter/sort), seeded with server-rendered products
-// so the initial HTML already contains the product grid.
+// so the initial HTML already contains the product grid. When the URL has a
+// ?q= param the component fetches search results client-side and shows them
+// instead of the full product list.
 export default function ProductsBrowser({ initialProducts = [] }) {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const q = searchParams.get('q')?.trim() || '';
+
   const [category, setCategory] = useState("all");
   const [priceRange, setPriceRange] = useState([0, 300]);
   const [sortBy, setSortBy] = useState("featured");
+  const [searchResults, setSearchResults] = useState(null); // null = no active search
+  const [searching, setSearching] = useState(false);
 
-  // Filter and sort products (logic lives in filter-products.mjs so it is unit-testable)
-  const filteredProducts = filterProducts(initialProducts, { category, priceRange, sortBy });
+  useEffect(() => {
+    if (!q) {
+      setSearchResults(null);
+      return;
+    }
+    setSearching(true);
+    searchProducts(q)
+      .then(res => {
+        setSearchResults(Array.isArray(res) ? res : []);
+        setSearching(false);
+      })
+      .catch(() => {
+        setSearchResults([]);
+        setSearching(false);
+      });
+  }, [q]);
+
+  const baseProducts = searchResults !== null ? searchResults : initialProducts;
+  const filteredProducts = filterProducts(baseProducts, { category, priceRange, sortBy });
 
   return (
     <div className="container mx-auto px-4 py-8">
+      {/* Search context banner */}
+      {q && (
+        <div className="mb-6 flex items-center justify-between rounded-md border bg-muted/50 px-4 py-3">
+          <p className="text-sm text-muted-foreground">
+            {searching
+              ? 'Searching…'
+              : `${searchResults?.length ?? 0} result${searchResults?.length === 1 ? '' : 's'} for "${q}"`}
+          </p>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => router.push('/products')}
+          >
+            Clear search
+          </Button>
+        </div>
+      )}
+
       {/* Filters and Sort */}
       <div className="mb-8 grid grid-cols-1 gap-4 md:grid-cols-3">
         <Select value={category} onValueChange={setCategory}>
@@ -83,9 +128,7 @@ export default function ProductsBrowser({ initialProducts = [] }) {
                 <p className="mb-3 text-sm text-muted-foreground">{product.description}</p>
                 <div className="flex items-center justify-between">
                   <span className="text-xl font-bold">${product.price}</span>
-                  <Button size="sm">
-                    View Details
-                  </Button>
+                  <Button size="sm">View Details</Button>
                 </div>
               </CardContent>
             </Card>
@@ -93,9 +136,9 @@ export default function ProductsBrowser({ initialProducts = [] }) {
         ))}
       </div>
 
-      {filteredProducts.length === 0 && (
+      {!searching && filteredProducts.length === 0 && (
         <div className="text-center text-muted-foreground">
-          No products found matching your criteria.
+          {q ? `No products found for "${q}".` : 'No products found matching your criteria.'}
         </div>
       )}
     </div>

--- a/components/site-header.js
+++ b/components/site-header.js
@@ -1,8 +1,9 @@
 'use client';
 
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { ShoppingBag, Search } from "lucide-react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { Button } from "./ui/button";
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuPortal, DropdownMenuContent } from "./ui/dropdown-menu";
 import { Input } from "./ui/input";
@@ -10,16 +11,30 @@ import { searchProducts } from '@/app/actions';
 import { useCart } from '@/lib/cart-context';
 
 export function SiteHeader() {
+  const [searchTerm, setSearchTerm] = useState('');
   const [searchResults, setSearchResults] = useState([]);
   const { itemCount, openCart } = useCart();
+  const router = useRouter();
+  const debounceRef = useRef(null);
 
-  function search(e) {
-    const target = e.target;
-    clearTimeout(target.searchTimeout);
-    target.searchTimeout = setTimeout(() => {
-      searchProducts(target.value)
+  function handleSearchChange(e) {
+    const value = e.target.value;
+    setSearchTerm(value);
+    clearTimeout(debounceRef.current);
+    if (!value.trim()) {
+      setSearchResults([]);
+      return;
+    }
+    debounceRef.current = setTimeout(() => {
+      searchProducts(value)
         .then(res => setSearchResults(Array.isArray(res) ? res : []));
     }, 300);
+  }
+
+  function handleSearchKeyDown(e) {
+    if (e.key === 'Enter' && searchTerm.trim()) {
+      router.push(`/products?q=${encodeURIComponent(searchTerm.trim())}`);
+    }
   }
 
   return (
@@ -45,9 +60,14 @@ export function SiteHeader() {
             <DropdownMenuPortal>
               <DropdownMenuContent style={{ width: 400, padding: 10 }}>
                 <h3 style={{ paddingBottom: 5 }}>Search</h3>
-                <div>
-                  <Input type="text" onChange={search} />
-                </div>
+                <Input
+                  type="text"
+                  placeholder="Search products… press Enter to see all results"
+                  value={searchTerm}
+                  onChange={handleSearchChange}
+                  onKeyDown={handleSearchKeyDown}
+                  autoFocus
+                />
                 <div style={{ paddingTop: 10, paddingBottom: 10 }}>
                   {searchResults.map(res => (
                     <Link key={`product-${res.id}`} href={`/products/${res.id}`}>
@@ -57,6 +77,11 @@ export function SiteHeader() {
                       </div>
                     </Link>
                   ))}
+                  {searchTerm.trim() && searchResults.length === 0 && (
+                    <div style={{ color: 'gray', fontSize: 12, paddingTop: 5 }}>
+                      No results — press Enter to search all products
+                    </div>
+                  )}
                 </div>
               </DropdownMenuContent>
             </DropdownMenuPortal>

--- a/config.yaml
+++ b/config.yaml
@@ -2,6 +2,10 @@ rest:
   webSocket: false
 graphqlSchema:
   files: '*.graphql'
+# Load .env before jsResource so OPENAI_API_KEY is in process.env when
+# resources.js runs, ensuring products are seeded with embeddings on startup.
+loadEnv:
+  files: '.env'
 jsResource:
   files: './resources.js'
 # Must load BEFORE @harperfast/nextjs: earlier-registered http listeners are


### PR DESCRIPTION
## Summary

Four changes on this branch, three of which fix the search feature end-to-end.

---

### 1. `searchProducts` returned empty results (raw Harper Records not serialized)

`searchProducts` returned raw Harper Record objects. Server-action RPC serialized them as `{}` so the dropdown showed blank entries and the results page showed nothing.

Fix: `JSON.parse(JSON.stringify(results))` — converts Harper Records to plain objects before returning, matching the pattern already used in `listProducts`.

---

### 2. Pressing Enter in the search bar did nothing

The search `<Input>` had an `onChange` handler for the live dropdown but no keyboard handler. There was no way to navigate to a results page.

Fix: `onKeyDown` in `SiteHeader` navigates to `/products?q=<term>` via `useRouter` when Enter is pressed. The debounced dropdown is preserved for quick single-product navigation. The input shows a placeholder explaining the Enter behaviour.

---

### 3. Products page had no awareness of `?q=` and always showed 0 results

`ProductsBrowser` had no mechanism to run a search or display results when navigated to `/products?q=<term>`.

Fix:
- `useSearchParams` reads the `q` param; a `useEffect` fires `searchProducts(q)` client-side whenever `q` changes
- A context banner shows result count and a Clear Search button
- A `Suspense` boundary wraps `ProductsBrowser` in `page.js` (required by Next.js for `useSearchParams`) without breaking ISR on the base `/products` route

---

### 4. Vector search returned 0 results even for exact product names

Root cause: `resources.js` runs at Harper startup, before `@harperfast/nextjs` launches Next.js and loads `.env`. `OPENAI_API_KEY` is absent at that point, so `EMBEDDINGS_ENABLED` is `false` and products are seeded **without** the `embedding` field. The HNSW index is empty.

When `searchProducts` later executes (in a server action, after Next.js has loaded `.env`), `EMBEDDINGS_ENABLED` is `true`, `embed()` succeeds, vector search is attempted — and silently returns `[]` because the HNSW index has no entries. No exception is raised; the results page simply shows 0 results.

Fix 1 — root cause: added `loadEnv` to `config.yaml` before `jsResource`. Harper's built-in `loadEnv` component parses `.env` into `process.env` before `resources.js` executes, so `OPENAI_API_KEY` is present and products are seeded with embeddings on startup.

Fix 2 — defence in depth: when vector search returns 0 results (empty HNSW index, API unavailable, or API key not yet set), `searchProducts` now falls through to a `contains` keyword search on the product name field instead of returning an empty array.

---

### 5. `.gitignore` update

Changed `/node_modules` to `**/node_modules` to cover nested `node_modules` directories.

---

## Behaviour after this PR

| Scenario | Result |
|----------|--------|
| Type in search box | Debounced dropdown shows matching products (names + descriptions visible) |
| Press Enter | Navigates to `/products?q=<term>`, result count banner shown |
| Filter/sort on results page | Works on the search result set |
| Clear Search button | Returns to full product listing |
| `OPENAI_API_KEY` set | Vector (HNSW) search on first restart after adding `loadEnv`; keyword fallback if HNSW still empty |
| No `OPENAI_API_KEY` | Keyword `contains` search on product name |

## Test plan

- [ ] Restart Harper after this change — products are reseeded with embeddings (if `OPENAI_API_KEY` is set)
- [ ] Type a keyword in the search box — dropdown shows product names and descriptions
- [ ] Press Enter — navigates to `/products?q=<term>`, banner shows result count
- [ ] Filter and sort controls work on search results
- [ ] Clear Search returns to full listing
- [ ] With `OPENAI_API_KEY`: search for a concept (e.g. "outdoor gear") returns semantically related products
- [ ] Without key or before restart: searching an exact product name (e.g. "Trail Runner X") returns that product via keyword fallback
- [ ] `npm run test:unit` — 27/27 pass
- [ ] `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)