### PR TITLE
fix: move server-timing to dependencies for production deploy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "harper-ecommerce-template",
-	"version": "0.1.0",
+	"version": "1.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "harper-ecommerce-template",
-			"version": "0.1.0",
+			"version": "1.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@harperfast/nextjs": "^2.0.0",
@@ -24,6 +24,7 @@
 				"openai": "^5.9.1",
 				"react": "^19.1.0",
 				"react-dom": "^19.1.0",
+				"server-timing": "file:./server-timing",
 				"zod": "^3.25.76"
 			},
 			"devDependencies": {
@@ -33,7 +34,6 @@
 				"@types/node": "24.0.14",
 				"@types/react": "^19.1.8",
 				"@types/react-dom": "^19.1.6",
-				"server-timing": "file:./server-timing",
 				"tailwind-merge": "^3.3.1",
 				"typescript": "^5.8.3"
 			}
@@ -10692,8 +10692,7 @@
 			}
 		},
 		"server-timing": {
-			"version": "1.0.0",
-			"dev": true
+			"version": "1.0.0"
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "harper-ecommerce-template",
-	"version": "0.1.0",
+	"version": "1.0.0",
 	"private": true,
 	"scripts": {
 		"dev": "HARPER_NEXTJS_MODE=dev harper run .",
@@ -22,6 +22,7 @@
 		"clsx": "^2.1.1",
 		"harper": "^5.0.28",
 		"lucide-react": "^0.525.0",
+		"server-timing": "file:./server-timing",
 		"next": "^15.5.19",
 		"openai": "^5.9.1",
 		"react": "^19.1.0",
@@ -29,7 +30,6 @@
 		"zod": "^3.25.76"
 	},
 	"devDependencies": {
-		"server-timing": "file:./server-timing",
 		"@harperdb/code-guidelines": "^0.0.6",
 		"@harperfast/integration-testing": "^0.4.0",
 		"@tailwindcss/postcss": "^4.1.11",

--- a/server-timing/package-lock.json
+++ b/server-timing/package-lock.json
@@ -1,0 +1,12 @@
+{
+	"name": "server-timing",
+	"version": "1.0.0",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "server-timing",
+			"version": "1.0.0"
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Moves `server-timing` from `devDependencies` to `dependencies` so it is installed in production environments
- Bumps package version to `1.0.0`
- Adds `server-timing/package-lock.json` for the local package

## Problem

The `server-timing` local package was listed under `devDependencies`, meaning it was not installed when running `npm install --omit=dev` (the default in production). This caused the Server-Timing header injection (added in PRs #16 and #17) to fail at runtime in deployed environments.

## Test plan

- [ ] Deploy to a production-like environment and confirm Server-Timing headers appear in responses
- [ ] Verify `npm install --omit=dev` installs `server-timing` correctly
- [ ] Confirm no regression in local dev (`npm run dev`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)